### PR TITLE
Workaround for phantom 1.9 bug reporting false warning (Unsafe JavaSc…

### DIFF
--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -125,7 +125,9 @@ var _takeScreenshot = function(status) {
     }
 
     page.close();
-    phantom.exit(0);
+    setTimeout(function() {
+      phantom.exit(0);
+    }, 0);
   }, options.renderDelay);
 }
 


### PR DESCRIPTION
…ript attempt to access frame with URL about:blank from frame with URL file:///...webshot.phantom.js. Domains, protocols and ports must match.)
